### PR TITLE
fix: use USERPROFILE on windows

### DIFF
--- a/schnose_gsi_client/src/config.rs
+++ b/schnose_gsi_client/src/config.rs
@@ -18,7 +18,7 @@ impl Config {
 		let mut home_dir = PathBuf::from(std::env::var("HOME")?);
 
 		#[cfg(windows)]
-		let mut home_dir = PathBuf::from(std::env::var("HOMEPATH")?);
+		let mut home_dir = PathBuf::from(std::env::var("USERPROFILE")?);
 
 		#[cfg(unix)]
 		home_dir.push(".config");


### PR DESCRIPTION
`USERPROFILE` has the drive letter in it while `HOMEDIR` does not. Program wouldn't run unless it was on the drive with the home directory.